### PR TITLE
make debug builds separate because they should be

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -23,12 +23,21 @@ jobs:
       id: date
       run: chmod +x Build.sh && ./Build.sh && echo "::set-output name=today::$(date +"%d-%m-%y--%H-%M-%S")"
     
-    - name: Upload Windows Relese and Debug
+    - name: Upload Windows Debug
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+            /home/runner/work/Meme-Downloader-2016/Meme-Downloader-2016/build/DEBUG-Meme Downloader 2016.exe
+        name: Meme Downloader 2016 Auto-Build (Dev) (DEBUG) (Windows)
+        tag_name: "${{ steps.date.outputs.today }}--DEBUG--Win"
+      env:
+        GITHUB_TOKEN: ${{ secrets.TEST }}
+    
+    - name: Upload Windows Release
       uses: softprops/action-gh-release@v1
       with:
         files: |
             /home/runner/work/Meme-Downloader-2016/Meme-Downloader-2016/build/Meme Downloader 2016.exe
-            /home/runner/work/Meme-Downloader-2016/Meme-Downloader-2016/build/DEBUG-Meme Downloader 2016.exe
         name: Meme Downloader 2016 Auto-Build (Windows)
         tag_name: "${{ steps.date.outputs.today }}--Win"
       env:

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -1,4 +1,4 @@
-name: Build `Meme Downloader 2016` For Windows
+name: Build Meme Downloader 2016 For Windows
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
imagine this


hey dude which exe should i download
the normal one
dude which one
the none debug one
ohhhh


this is why debug builds should be separate (added dev tags to hopefully remove any confoosion)