### PR TITLE
Completely remove the use of zipper

### DIFF
--- a/.github/workflows/Test_Build.yml
+++ b/.github/workflows/Test_Build.yml
@@ -26,4 +26,4 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
           name: Things-The-Bot-Downloaded.zip
-          path: '.\build\Downloaded-Content.zip'
+          path: '.\build\Downloaded Content'

--- a/Build.bat
+++ b/Build.bat
@@ -18,19 +18,3 @@ cd .\build\
 echo 'Executing Meme Downloader 2016 in CI mode'
 
 ".\Meme Downloader 2016.exe" -ci
-
-
-
-echo 'Compiling Zipper.exe and making all downloaded content onto a zip!'
-
-git clone https://github.com/usrDottik/Zipper.git
-
-cd Zipper\
-
-dotnet publish "Zipper.csproj" --output build\ --arch x64 --os win -c release --self-contained true
-
-mv build\Zipper.exe ..
-
-cd ..
-
-Zipper.exe -Output=Downloaded-Content.zip -LocalFile -Folder="Downloaded Content" 


### PR DESCRIPTION
Why? Zipper isn’t needed and zip in a zip especially at that size is very large and can take double the time to extract 